### PR TITLE
fixed query header, added support for paritition keys and across all …

### DIFF
--- a/Demo/Demo Query DDB3.ps1
+++ b/Demo/Demo Query DDB3.ps1
@@ -1,0 +1,18 @@
+﻿$AccountName = '<acc>'
+$Key = '<DDBKey>'
+$Database = '<db>'
+$Collection = '<coll>'
+$id = '622046c70210ae5c13dee9e3bc2f0ff2'
+
+$Query = @"
+{      
+    "query": "SELECT * FROM $collection r WHERE r.id = @id",     
+    "parameters": [          
+        { "name": "@id", "value": $id }         
+    ] 
+}
+"@
+
+$temp = New-DocDBQuery -DBName $Database -accountName $AccountName -key $key -collection $Collection -JSONQuery $Query -EnableCrossPartitionQuery
+$temp
+

--- a/Demo/Demo Query DDB4.ps1
+++ b/Demo/Demo Query DDB4.ps1
@@ -1,0 +1,15 @@
+﻿$AccountName = '<acc>'
+$Key = '<DDBKey>'
+$Database = '<db>'
+$Collection = '<coll>'
+$partitionKey = '622046c70210ae5c13dee9e3bc2f0ff2'
+
+$Query = @"
+{      
+    "query": "SELECT * FROM $collection"      
+}
+"@
+
+$temp = New-DocDBQuery -DBName $Database -accountName $AccountName -key $key -collection $Collection -JSONQuery $Query -partitionKey $partitionKey
+$temp
+


### PR DESCRIPTION
updated REST API version to latest
added header support for `x-ms-documentdb-query-enablecrosspartition` and `x-ms-documentdb-partitionkey`
added response error output for queries to help troubleshooting
fixed wrong header assignment in New-DocDBQuery